### PR TITLE
Inject a Kafka dialer rather than a client

### DIFF
--- a/eventbus/kafka/eventbus.go
+++ b/eventbus/kafka/eventbus.go
@@ -83,12 +83,12 @@ func NewEventBus(addressList, appID string, options ...Option) (*EventBus, error
 		}
 	}
 
-	// Use the default Kafka dialer if none was provided.
 	b.client = &kafka.Client{
 		Addr:      kafka.TCP(addrSplit...),
 		Transport: kafka.DefaultTransport,
 	}
 
+	// If a dialer was configured, use its timeout, SASL auth, and TLS in the client transport.
 	if b.dialer != nil {
 		b.client.Transport = &kafka.Transport{
 			DialTimeout: b.dialer.Timeout,
@@ -114,6 +114,7 @@ func NewEventBus(addressList, appID string, options ...Option) (*EventBus, error
 		Balancer:     &kafka.Hash{},    // Hash by aggregate ID.
 	}
 
+	// If a dialer was configured, use its timeout, SASL auth, and TLS in the writer transport.
 	if b.dialer != nil {
 		b.writer.Transport = &kafka.Transport{
 			DialTimeout: b.dialer.Timeout,
@@ -336,6 +337,7 @@ func (b *EventBus) AddHandler(ctx context.Context, m eh.EventMatcher, h eh.Event
 		StartOffset:           b.startOffset,
 	}
 
+	// Use a customer dialer if one was configured.
 	if b.dialer != nil {
 		readerConfig.Dialer = b.dialer
 	}

--- a/eventbus/kafka/eventbus_test.go
+++ b/eventbus/kafka/eventbus_test.go
@@ -154,30 +154,30 @@ func TestWithAutoCreateTopic(t *testing.T) {
 	}
 }
 
-func TestWithClient(t *testing.T) {
+func TestWithDialer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 
 	testCases := map[string]struct {
-		client *kafka.Client
+		dialer *kafka.Dialer
 	}{
 		"no client": {nil},
-		"custom client": {&kafka.Client{
-			Addr: kafka.TCP("custom.addr"),
+		"custom client": {&kafka.Dialer{
+			ClientID: "custom-dialer-client-id",
 		}},
 	}
 
 	for desc, tc := range testCases {
 		t.Run(desc, func(t *testing.T) {
-			eb, _, err := newTestEventBus("", WithClient(tc.client))
+			eb, _, err := newTestEventBus("", WithDialer(tc.dialer))
 			if err != nil {
 				t.Fatalf("expected no error, got: %s", err.Error())
 			}
 
 			underlyingEb := eb.(*EventBus)
-			if want, got := tc.client.Addr.String(), underlyingEb.client.Addr.String(); want != got {
-				t.Fatalf("expected client addr to be %s, got: %s", want, got)
+			if want, got := tc.dialer.ClientID, underlyingEb.dialer.ClientID; want != got {
+				t.Fatalf("expected client ID in dialer to be %s, got: %s", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
Rather than injecting a `kafka.Client`, inject a `kafka.Dialer` that can be used when creating clients, readers, and writers.